### PR TITLE
Add new datatype supported for 'arg' nodes

### DIFF
--- a/PyQT5_GUI_Builder.py
+++ b/PyQT5_GUI_Builder.py
@@ -57,6 +57,7 @@ class XmlCommonAttrValues(Enum):
     ARG_TYPE_INTEGER = 'int'
     ARG_TYPE_STRING = 'str'
     ARG_TYPE_VARIABLE = 'var'
+    ARG_TYPE_SELF = 'self'
     ARG_KIND_NAMED = 'named'
     ARG_KIND_UNNAMED = 'unnamed'
 
@@ -324,6 +325,11 @@ class PyQT5_GUI_Builder:
             # object based on its parent's type.
             if arg_type == XmlCommonAttrValues.ARG_TYPE_VARIABLE.value:
                 arg_value = cls.getObjectBasedOnParentType(arg, modules_data, arg_value, current_object, base_object)
+
+            # If the argument has "self" datatype specified, the value that has to be passed is a reference to the
+            # current object that is being created
+            if arg_type == XmlCommonAttrValues.ARG_TYPE_SELF.value:
+                arg_value = current_object
 
             # Add this argument to relevant container based on its 'kind' XML attribute
             if arg_kind == XmlCommonAttrValues.ARG_KIND_NAMED.value:

--- a/Resources/Settings/EX1_QLabel_And_QLineEdit.xml
+++ b/Resources/Settings/EX1_QLabel_And_QLineEdit.xml
@@ -48,9 +48,13 @@
 						here - by 'arg' nodes. Every 'arg' node should have 'value', 'type', and 'kind' attribute:
 						- value - the content of the constructor argument,
 						- type - datatype of the argument (so far the 'str', 'int' and 'var' are supported).
-							'var' stands for variable object from some module/object in python program.
-							Then, the 'value' should contain the string name of the variable object. In this case
+							* 'var' stands for variable object from some module/object in the python program.
+							The 'value' should contain the string name of the variable object. In this case
 							there must be also 'parent_type_id' attribute specified.
+							* 'self' stands for the current component that is being created based on XML 'component' node.
+							So this type of parameter should not be used inside 'constructor_args' node. It can be used
+							inside 'feature_args' node. With this datatype, the 'value' attribute is not used - leave
+							an empty string for example.
 						- kind - specified if the argument is named or unnamed. If 'named', there also must be
 							'arg_name' attribute specified. -->
 						<arg value="Some basic text" type="str" kind="unnamed"/>

--- a/Resources/Settings/EX2_2_Rows_Of_QLabel_And_QLineEdit.xml
+++ b/Resources/Settings/EX2_2_Rows_Of_QLabel_And_QLineEdit.xml
@@ -52,9 +52,13 @@
 								here - by 'arg' nodes. Every 'arg' node should have 'value', 'type', and 'kind' attribute:
 								- value - the content of the constructor argument,
 								- type - datatype of the argument (so far the 'str', 'int' and 'var' are supported).
-									'var' stands for variable object from some module/object in python program.
-									Then, the 'value' should contain the string name of the variable object. In this case
+									* 'var' stands for variable object from some module/object in the python program.
+									The 'value' should contain the string name of the variable object. In this case
 									there must be also 'parent_type_id' attribute specified.
+									* 'self' stands for the current component that is being created based on XML 'component' node.
+									So this type of parameter should not be used inside 'constructor_args' node. It can be used
+									inside 'feature_args' node. With this datatype, the 'value' attribute is not used - leave
+									an empty string for example.
 								- kind - specified if the argument is named or unnamed. If 'named', there also must be
 									'arg_name' attribute specified. -->
 								<arg value="Label 1st row" type="str" kind="unnamed"/>

--- a/Resources/Settings/EX3_TwoButtonsWithDifferentMethods.xml
+++ b/Resources/Settings/EX3_TwoButtonsWithDifferentMethods.xml
@@ -47,10 +47,14 @@
 						<!-- If constructor of the component object requires some arguments, they can be defined
 						here - by 'arg' nodes. Every 'arg' node should have 'value', 'type', and 'kind' attribute:
 						- value - the content of the constructor argument,
-						- type - datatype of the argument (so far the 'str', 'int' and 'var' are supported).
-							'var' stands for variable object from some module/object in python program.
-							Then, the 'value' should contain the string name of the variable object. In this case
+						- type - datatype of the argument (so far the 'str', 'int', 'var' and 'self' are supported).
+							* 'var' stands for variable object from some module/object in the python program.
+							The 'value' should contain the string name of the variable object. In this case
 							there must be also 'parent_type_id' attribute specified.
+							* 'self' stands for the current component that is being created based on XML 'component' node.
+							So this type of parameter should not be used inside 'constructor_args' node. It can be used
+							inside 'feature_args' node. With this datatype, the 'value' attribute is not used - leave
+							an empty string for example.
 						- kind - specified if the argument is named or unnamed. If 'named', there also must be
 							'arg_name' attribute specified. -->
 						<arg value="Connected to global function" type="str" kind="unnamed"/>


### PR DESCRIPTION
Attribute 'type' of 'arg' node can have 'self' value. It means that the reference to the current component that is being created should be passed as an argument to the destination function.